### PR TITLE
Move to config into a config file, add new commands and updated readme

### DIFF
--- a/CarbonCopy.lua
+++ b/CarbonCopy.lua
@@ -71,7 +71,6 @@ function cc_CopyCharacter(event, player, command, chatHandler)
         if player == nil and ccSubCommandConsole == "tickets" then
             if commandArray[3] == nil then
                 chatHandler:SendSysMessage("Syntax: .carboncopy tickets lookup $characterName")
-                chatHandler:SendSysMessage("Syntax: .carboncopy tickets $characterName")
                 chatHandler:SendSysMessage("Syntax: .carboncopy tickets add $characterName $amount")
                 cc_resetVariables()
                 return false
@@ -123,14 +122,18 @@ function cc_CopyCharacter(event, player, command, chatHandler)
                 return false
             end
 
-            local lookupNameArg = commandArray[3]
-            if ticketsAction == "lookup" then
-                if commandArray[4] == nil then
-                    chatHandler:SendSysMessage("Syntax: .carboncopy tickets lookup $characterName")
-                    cc_resetVariables()
-                    return false
-                end
-                lookupNameArg = commandArray[4]
+            if ticketsAction ~= "lookup" then
+                chatHandler:SendSysMessage("Syntax: .carboncopy tickets lookup $characterName")
+                chatHandler:SendSysMessage("Syntax: .carboncopy tickets add $characterName $amount")
+                cc_resetVariables()
+                return false
+            end
+
+            local lookupNameArg = commandArray[4]
+            if lookupNameArg == nil then
+                chatHandler:SendSysMessage("Syntax: .carboncopy tickets lookup $characterName")
+                cc_resetVariables()
+                return false
             end
 
             local lookupCharacterName = cc_normalizeCharacterName(lookupNameArg)
@@ -171,7 +174,6 @@ function cc_CopyCharacter(event, player, command, chatHandler)
         if commandArray[2] == "help" then
             chatHandler:SendSysMessage("Syntax: .carboncopy $newCharacterName")
             chatHandler:SendSysMessage("Syntax: .carboncopy tickets lookup $characterName")
-            chatHandler:SendSysMessage("Syntax: .carboncopy tickets $characterName")
             chatHandler:SendSysMessage("Syntax: .carboncopy tickets add $characterName $amount")
             cc_resetVariables()
             return false
@@ -197,7 +199,6 @@ function cc_CopyCharacter(event, player, command, chatHandler)
         if ccSubCommand == "tickets" then
             if commandArray[3] == nil then
                 chatHandler:SendSysMessage("Syntax: .carboncopy tickets lookup $characterName")
-                chatHandler:SendSysMessage("Syntax: .carboncopy tickets $characterName")
                 chatHandler:SendSysMessage("Syntax: .carboncopy tickets add $characterName $amount")
                 cc_resetVariables()
                 return false
@@ -255,14 +256,18 @@ function cc_CopyCharacter(event, player, command, chatHandler)
                 return false
             end
 
-            local lookupNameArg = commandArray[3]
-            if ticketsAction == "lookup" then
-                if commandArray[4] == nil then
-                    chatHandler:SendSysMessage("Syntax: .carboncopy tickets lookup $characterName")
-                    cc_resetVariables()
-                    return false
-                end
-                lookupNameArg = commandArray[4]
+            if ticketsAction ~= "lookup" then
+                chatHandler:SendSysMessage("Syntax: .carboncopy tickets lookup $characterName")
+                chatHandler:SendSysMessage("Syntax: .carboncopy tickets add $characterName $amount")
+                cc_resetVariables()
+                return false
+            end
+
+            local lookupNameArg = commandArray[4]
+            if lookupNameArg == nil then
+                chatHandler:SendSysMessage("Syntax: .carboncopy tickets lookup $characterName")
+                cc_resetVariables()
+                return false
             end
 
             local lookupCharacterName = cc_normalizeCharacterName(lookupNameArg)

--- a/CarbonCopy.lua
+++ b/CarbonCopy.lua
@@ -44,6 +44,12 @@ function cc_CopyCharacter(event, player, command, chatHandler)
         if commandArray[3] ~= nil then
             commandArray[3] = commandArray[3]:gsub("[';\\, ]", "")
         end
+        if commandArray[4] ~= nil then
+            commandArray[4] = commandArray[4]:gsub("[';\\, ]", "")
+        end
+        if commandArray[5] ~= nil then
+            commandArray[5] = commandArray[5]:gsub("[';\\, ]", "")
+        end
     end
 
     if commandArray[1] ~= "carboncopy" and commandArray[1] ~= "addcctickets" and commandArray[1] ~= "CCACCOUNTTICKETS" then
@@ -64,12 +70,70 @@ function cc_CopyCharacter(event, player, command, chatHandler)
 
         if player == nil and ccSubCommandConsole == "tickets" then
             if commandArray[3] == nil then
-                chatHandler:SendSysMessage("Syntax: .carboncopy tickets $CharacterName")
+                chatHandler:SendSysMessage("Syntax: .carboncopy tickets lookup $characterName")
+                chatHandler:SendSysMessage("Syntax: .carboncopy tickets $characterName")
+                chatHandler:SendSysMessage("Syntax: .carboncopy tickets add $characterName $amount")
                 cc_resetVariables()
                 return false
             end
 
-            local lookupCharacterName = cc_normalizeCharacterName(commandArray[3])
+            local ticketsAction = string.lower(commandArray[3])
+            if ticketsAction == "add" then
+                if commandArray[4] == nil or commandArray[5] == nil then
+                    chatHandler:SendSysMessage("Syntax: .carboncopy tickets add $characterName $amount")
+                    cc_resetVariables()
+                    return false
+                end
+
+                if tonumber(commandArray[5]) == nil or tonumber(commandArray[5]) > 1000 or tonumber(commandArray[5]) < 0 then
+                    chatHandler:SendSysMessage("Too large or negative amount chosen for .carboncopy tickets add: "..commandArray[5]..". Max allowed is +1000.")
+                    cc_resetVariables()
+                    return false
+                end
+
+                local normalisedCharacterName = cc_normalizeCharacterName(commandArray[4])
+                local Data_SQL = CharDBQuery("SELECT `account` FROM `characters` WHERE `name` = '"..normalisedCharacterName.."' LIMIT 1;")
+                local accountId
+                local oldTickets
+                if Data_SQL ~= nil then
+                    accountId = Data_SQL:GetUInt32(0)
+                else
+                    chatHandler:SendSysMessage("Player name not found. Syntax: .carboncopy tickets add $characterName $amount")
+                    cc_resetVariables()
+                    return false
+                end
+
+                Data_SQL = CharDBQuery('SELECT `tickets` FROM `'..Config.customDbName..'`.`carboncopy` WHERE `account_id` = '..accountId..' LIMIT 1;')
+                if Data_SQL ~= nil then
+                    oldTickets = Data_SQL:GetUInt32(0)
+                else
+                    oldTickets = 0
+                end
+
+                if oldTickets >= 1000 or oldTickets < 0 then
+                    chatHandler:SendSysMessage("Too large total amount tickets: "..commandArray[5]..". Max allowed total is +1000. Current value: "..oldTickets)
+                    cc_resetVariables()
+                    return false
+                end
+
+                CharDBQuery('DELETE FROM `'..Config.customDbName..'`.`carboncopy` WHERE `account_id` = '..accountId..';')
+                CharDBQuery('INSERT INTO `'..Config.customDbName..'`.`carboncopy` VALUES ('..accountId..', '..commandArray[5] + oldTickets..', 0);')
+                chatHandler:SendSysMessage("The console has sucessfully used the .carboncopy tickets add command, adding "..commandArray[5].." tickets to the account "..accountId.." which belongs to player "..normalisedCharacterName..".")
+                cc_resetVariables()
+                return false
+            end
+
+            local lookupNameArg = commandArray[3]
+            if ticketsAction == "lookup" then
+                if commandArray[4] == nil then
+                    chatHandler:SendSysMessage("Syntax: .carboncopy tickets lookup $characterName")
+                    cc_resetVariables()
+                    return false
+                end
+                lookupNameArg = commandArray[4]
+            end
+
+            local lookupCharacterName = cc_normalizeCharacterName(lookupNameArg)
             local Data_SQL = CharDBQuery('SELECT `account` FROM `characters` WHERE `name` = "'..lookupCharacterName..'" LIMIT 1;')
             if Data_SQL == nil then
                 chatHandler:SendSysMessage("Character name not found. Check spelling.")
@@ -93,7 +157,7 @@ function cc_CopyCharacter(event, player, command, chatHandler)
 
         if player == nil then
             chatHandler:SendSysMessage("This command can not be run from the console, but only from the character to copy.")
-            chatHandler:SendSysMessage("Expected syntax: .addcctickets $CharacterName $Amount")
+            chatHandler:SendSysMessage("Syntax: .addcctickets $characterName $amount")
             return false
         end
         -- make sure the player is properly ranked
@@ -105,7 +169,10 @@ function cc_CopyCharacter(event, player, command, chatHandler)
 
         -- provide syntax help
         if commandArray[2] == "help" then
-            chatHandler:SendSysMessage("Syntax: .carboncopy $NewCharacterName")
+            chatHandler:SendSysMessage("Syntax: .carboncopy $newCharacterName")
+            chatHandler:SendSysMessage("Syntax: .carboncopy tickets lookup $characterName")
+            chatHandler:SendSysMessage("Syntax: .carboncopy tickets $characterName")
+            chatHandler:SendSysMessage("Syntax: .carboncopy tickets add $characterName $amount")
             cc_resetVariables()
             return false
         end
@@ -129,12 +196,76 @@ function cc_CopyCharacter(event, player, command, chatHandler)
         local ccSubCommand = string.lower(commandArray[2])
         if ccSubCommand == "tickets" then
             if commandArray[3] == nil then
-                chatHandler:SendSysMessage("Syntax: .carboncopy tickets $CharacterName")
+                chatHandler:SendSysMessage("Syntax: .carboncopy tickets lookup $characterName")
+                chatHandler:SendSysMessage("Syntax: .carboncopy tickets $characterName")
+                chatHandler:SendSysMessage("Syntax: .carboncopy tickets add $characterName $amount")
                 cc_resetVariables()
                 return false
             end
 
-            local lookupCharacterName = cc_normalizeCharacterName(commandArray[3])
+            local ticketsAction = string.lower(commandArray[3])
+            if ticketsAction == "add" then
+                if player:GetGMRank() < Config.minGMRankForTickets then
+                    chatHandler:SendSysMessage("You lack permisisions to execute this command.")
+                    cc_resetVariables()
+                    return false
+                end
+
+                if commandArray[4] == nil or commandArray[5] == nil then
+                    chatHandler:SendSysMessage("Syntax: .carboncopy tickets add $characterName $amount")
+                    cc_resetVariables()
+                    return false
+                end
+
+                if tonumber(commandArray[5]) == nil or tonumber(commandArray[5]) > 1000 or tonumber(commandArray[5]) < 0 then
+                    chatHandler:SendSysMessage("Too large or negative amount chosen for .carboncopy tickets add: "..commandArray[5]..". Max allowed is +1000.")
+                    cc_resetVariables()
+                    return false
+                end
+
+                local normalisedCharacterName = cc_normalizeCharacterName(commandArray[4])
+                local Data_SQL = CharDBQuery("SELECT `account` FROM `characters` WHERE `name` = '"..normalisedCharacterName.."' LIMIT 1;")
+                local addAccountId
+                local oldTickets
+                if Data_SQL ~= nil then
+                    addAccountId = Data_SQL:GetUInt32(0)
+                else
+                    chatHandler:SendSysMessage("Player name not found. Syntax: .carboncopy tickets add $characterName $amount")
+                    cc_resetVariables()
+                    return false
+                end
+
+                Data_SQL = CharDBQuery('SELECT `tickets` FROM `'..Config.customDbName..'`.`carboncopy` WHERE `account_id` = '..addAccountId..' LIMIT 1;')
+                if Data_SQL ~= nil then
+                    oldTickets = Data_SQL:GetUInt32(0)
+                else
+                    oldTickets = 0
+                end
+
+                if oldTickets >= 1000 or oldTickets < 0 then
+                    chatHandler:SendSysMessage("Too large total amount tickets: "..commandArray[5]..". Max allowed total is +1000. Current value: "..oldTickets)
+                    cc_resetVariables()
+                    return false
+                end
+
+                CharDBQuery('DELETE FROM `'..Config.customDbName..'`.`carboncopy` WHERE `account_id` = '..addAccountId..';')
+                CharDBQuery('INSERT INTO `'..Config.customDbName..'`.`carboncopy` VALUES ('..addAccountId..', '..commandArray[5] + oldTickets..', 0);')
+                chatHandler:SendSysMessage("GM "..player:GetName().. " has sucessfully used the .carboncopy tickets add command, adding "..commandArray[5].." tickets to the account "..addAccountId.." which belongs to player "..normalisedCharacterName..".")
+                cc_resetVariables()
+                return false
+            end
+
+            local lookupNameArg = commandArray[3]
+            if ticketsAction == "lookup" then
+                if commandArray[4] == nil then
+                    chatHandler:SendSysMessage("Syntax: .carboncopy tickets lookup $characterName")
+                    cc_resetVariables()
+                    return false
+                end
+                lookupNameArg = commandArray[4]
+            end
+
+            local lookupCharacterName = cc_normalizeCharacterName(lookupNameArg)
             local Data_SQL = CharDBQuery('SELECT `account` FROM `characters` WHERE `name` = "'..lookupCharacterName..'" LIMIT 1;')
             if Data_SQL == nil then
                 chatHandler:SendSysMessage("Character name not found. Check spelling.")
@@ -577,6 +708,7 @@ function cc_CopyCharacter(event, player, command, chatHandler)
         return false
 
     elseif commandArray[1] == "addcctickets" then
+        -- Kept for Legacy / Compotability
         -- make sure the player is properly ranked
         local accountId
         local oldTickets
@@ -587,12 +719,12 @@ function cc_CopyCharacter(event, player, command, chatHandler)
                 return false
             end
             if commandArray[2] == "help" then
-                chatHandler:SendSysMessage("Syntax: .addcctickets $CharacterName $Amount")
+                chatHandler:SendSysMessage("Syntax: .addcctickets $characterName $amount")
                 cc_resetVariables()
                 return false
             end
             if commandArray[2] == nil or commandArray[3] == nil then
-                chatHandler:SendSysMessage("Expected syntax: .addcctickets $CharacterName $Amount")
+                chatHandler:SendSysMessage("Syntax: .addcctickets $characterName $amount")
                 cc_resetVariables()
                 return false
             end
@@ -608,7 +740,7 @@ function cc_CopyCharacter(event, player, command, chatHandler)
             if Data_SQL ~= nil then
                 accountId = Data_SQL:GetUInt32(0)
             else
-                chatHandler:SendSysMessage("Player name not found. Expected syntax: .addcctickets [CharacterName] [Amount]")
+                chatHandler:SendSysMessage("Player name not found. Syntax: .addcctickets $characterName $amount")
                 cc_resetVariables()
                 return false
             end
@@ -639,12 +771,12 @@ function cc_CopyCharacter(event, player, command, chatHandler)
         else
             --player is nil, must be the console. no need to check gm rank and print to console only. not chat
             if commandArray[2] == "help" then
-                chatHandler:SendSysMessage("Syntax: .addcctickets $CharacterName $Amount")
+                chatHandler:SendSysMessage("Syntax: .addcctickets $characterName $amount")
                 cc_resetVariables()
                 return false
             end
             if commandArray[2] == nil or commandArray[3] == nil then
-                chatHandler:SendSysMessage("Expected syntax: .addcctickets $CharacterName $Amount")
+                chatHandler:SendSysMessage("Syntax: .addcctickets $characterName $amount")
                 cc_resetVariables()
                 return false
             end
@@ -660,7 +792,7 @@ function cc_CopyCharacter(event, player, command, chatHandler)
             if Data_SQL ~= nil then
                 accountId = Data_SQL:GetUInt32(0)
             else
-                chatHandler:SendSysMessage("Player name not found. Expected syntax: .addcctickets [CharacterName] [Amount]")
+                chatHandler:SendSysMessage("Player name not found. Syntax: .addcctickets $characterName $amount")
                 cc_resetVariables()
                 return false
             end
@@ -727,7 +859,7 @@ function cc_CopyCharacter(event, player, command, chatHandler)
         chatHandler:SendSysMessage("'CCACCOUNTTICKETS $accountName $amount' only works against SOAP / the console.")
         return false
     else
-        chatHandler:SendSysMessage("Expected Syntax: CCACCOUNTTICKETS $accountName $amount")
+        chatHandler:SendSysMessage("Syntax: CCACCOUNTTICKETS $accountName $amount")
         return false
     end
 end

--- a/CarbonCopy.lua
+++ b/CarbonCopy.lua
@@ -57,6 +57,40 @@ function cc_CopyCharacter(event, player, command, chatHandler)
     end
 
     if commandArray[1] == "carboncopy" then
+        local ccSubCommandConsole = nil
+        if commandArray[2] ~= nil then
+            ccSubCommandConsole = string.lower(commandArray[2])
+        end
+
+        if player == nil and ccSubCommandConsole == "tickets" then
+            if commandArray[3] == nil then
+                chatHandler:SendSysMessage("Syntax: .carboncopy tickets $CharacterName")
+                cc_resetVariables()
+                return false
+            end
+
+            local lookupCharacterName = cc_normalizeCharacterName(commandArray[3])
+            local Data_SQL = CharDBQuery('SELECT `account` FROM `characters` WHERE `name` = "'..lookupCharacterName..'" LIMIT 1;')
+            if Data_SQL == nil then
+                chatHandler:SendSysMessage("Character name not found. Check spelling.")
+                cc_resetVariables()
+                return false
+            end
+
+            local lookupAccountId = Data_SQL:GetUInt32(0)
+            Data_SQL = CharDBQuery('SELECT `tickets` FROM `'..Config.customDbName..'`.`carboncopy` WHERE `account_id` = '..lookupAccountId..' LIMIT 1;')
+            local lookupTickets
+            if Data_SQL ~= nil then
+                lookupTickets = Data_SQL:GetUInt32(0)
+            else
+                lookupTickets = Config.freeTickets
+            end
+
+            chatHandler:SendSysMessage("CarbonCopy tickets for "..lookupCharacterName.." (account "..lookupAccountId.."): "..lookupTickets)
+            cc_resetVariables()
+            return false
+        end
+
         if player == nil then
             chatHandler:SendSysMessage("This command can not be run from the console, but only from the character to copy.")
             chatHandler:SendSysMessage("Expected syntax: .addcctickets $CharacterName $Amount")
@@ -91,6 +125,37 @@ function cc_CopyCharacter(event, player, command, chatHandler)
             cc_resetVariables()
             return false
         end
+
+        local ccSubCommand = string.lower(commandArray[2])
+        if ccSubCommand == "tickets" then
+            if commandArray[3] == nil then
+                chatHandler:SendSysMessage("Syntax: .carboncopy tickets $CharacterName")
+                cc_resetVariables()
+                return false
+            end
+
+            local lookupCharacterName = cc_normalizeCharacterName(commandArray[3])
+            local Data_SQL = CharDBQuery('SELECT `account` FROM `characters` WHERE `name` = "'..lookupCharacterName..'" LIMIT 1;')
+            if Data_SQL == nil then
+                chatHandler:SendSysMessage("Character name not found. Check spelling.")
+                cc_resetVariables()
+                return false
+            end
+
+            local lookupAccountId = Data_SQL:GetUInt32(0)
+            Data_SQL = CharDBQuery('SELECT `tickets` FROM `'..Config.customDbName..'`.`carboncopy` WHERE `account_id` = '..lookupAccountId..' LIMIT 1;')
+            local lookupTickets
+            if Data_SQL ~= nil then
+                lookupTickets = Data_SQL:GetUInt32(0)
+            else
+                lookupTickets = Config.freeTickets
+            end
+
+            chatHandler:SendSysMessage("CarbonCopy tickets for "..lookupCharacterName.." (account "..lookupAccountId.."): "..lookupTickets)
+            cc_resetVariables()
+            return false
+        end
+
         -- check maxLevel
         if player:GetLevel() > Config.maxLevel then
             chatHandler:SendSysMessage("The character you want to copy from is too high level. Max level is "..Config.maxLevel..". Aborting.")

--- a/CarbonCopy.lua
+++ b/CarbonCopy.lua
@@ -135,7 +135,7 @@ function cc_CopyCharacter(event, player, command, chatHandler)
         cc_playerGUID = tostring(player:GetGUID())
         cc_playerGUID = tonumber(cc_playerGUID)
         local targetName = cc_normalizeCharacterName(commandArray[2])
-    
+
         --check for target character to be on same account
         local Data_SQL = CharDBQuery('SELECT `account` FROM `characters` WHERE `name` = "'..targetName..'" LIMIT 1;');
         if Data_SQL == nil then
@@ -231,7 +231,7 @@ function cc_CopyCharacter(event, player, command, chatHandler)
         if Data_SQL ~= nil then
             cc_cinematic = Data_SQL:GetUInt16(0)
             if cc_cinematic == 1 then
-                chatHandler:SendSysMessage("The requested character has been logged in already. Aborting.")
+                chatHandler:SendSysMessage("The requested character has been logged in already (or has already been Carbon Copied). Aborting.")
                 cc_cinematic = nil
                 cc_resetVariables()
                 return false
@@ -246,7 +246,7 @@ function cc_CopyCharacter(event, player, command, chatHandler)
         if Data_SQL ~= nil then
             cc_online = Data_SQL:GetUInt16(0)
             if cc_online == 1 then
-                chatHandler:SendSysMessage("The requested character has been logged in already. Aborting.")
+                chatHandler:SendSysMessage("The requested character has been logged in already (or has already been Carbon Copied). Aborting.")
                 cc_online = nil
                 cc_resetVariables()
                 return false
@@ -269,7 +269,7 @@ function cc_CopyCharacter(event, player, command, chatHandler)
         Ban(1, targetName, 15, "CarbonCopy", "CarbonCopy" )
         cc_scriptIsBusy = 1
         cc_newCharacter = newCharacter
-        
+
         -- save the source character to db to prevent recent changes from being not applied
         player:SaveToDB()
 
@@ -532,6 +532,8 @@ function cc_CopyCharacter(event, player, command, chatHandler)
 
         return false
         end)
+
+        return false
 
     elseif commandArray[1] == "addcctickets" then
         -- make sure the player is properly ranked

--- a/CarbonCopy.lua
+++ b/CarbonCopy.lua
@@ -9,7 +9,7 @@
 
 ------------------------------------------------------------------------------------------------
 -- ADMIN GUIDE:  -  compile the core with ElunaLua module
---               -  adjust config in this file
+--               -  adjust config in Acore_CarbonCopy/CarbonCopy_Config.lua
 --               -  add this script to ../lua_scripts/
 --               -  grant account related tickets in the `carboncopy` table
 -- PLAYER USAGE: 1) create a new character with same class/race as the one to copy in the same account. Do NOT log it in
@@ -17,47 +17,10 @@
 --               3) .carboncopy newToonsName
 ------------------------------------------------------------------------------------------------
 
-local Config = {};
-local cc_maps = {};
-local ticket_Cost = {};
-
--- Name of Eluna dB scheme
-Config.customDbName = 'ac_eluna';
--- Min GM Level to use the .carboncopy command. Set to 0 for all players.
-Config.minGMRankForCopy = 0;
--- Min GM Level to add tickets to an account.
-Config.minGMRankForTickets = 2;
--- The amount of free tickets to grant when .carboncopy is executed for the first time on that account
-Config.freeTickets = 1;
--- This text is added to the mail which the new character receives alongside their copied items
-Config.mailText = ",\n \n here you are your gear. Have fun with the new twink!\n \n- Sincerely,\n the team of ChromieCraft!";
--- Maximum level to allow copying a character.
-Config.maxLevel = 49;
--- Whether the ticket amount withdrawn for a copy is always 1 (set it to "single") or depends on the level (set this to "level")
-Config.ticketCost = "level";
--- Here you can adjust the cost in tickets if Config.ticketCost is set to "level"
-ticket_Cost[19] = 1		--it costs 1 ticket to copy a character up to level 19
-ticket_Cost[29] = 2
-ticket_Cost[39] = 3
-ticket_Cost[49] = 5
-ticket_Cost[59] = 8
-ticket_Cost[69] = 12
-ticket_Cost[79] = 18
-ticket_Cost[80] = 25	--it costs 25 tickets to copy a character at level 80
-
--- The ItemID "38" (Recruit's Shirt) will be sent on the mail if slot is empty or doesn't exist.
--- Applies for Shaman Totems "totemItem[X]" and for nill slots in "item_id[i]".
-
--- The maps below specify legal locations to use the .carboncopy command.
--- This is used to prevent dungeon specific gear to be copied e.g. the legendaries from the Kael'thas encounter.
--- Eastern kingdoms
-table.insert(cc_maps, 0)
--- Kalimdor
-table.insert(cc_maps, 1)
--- Outland
-table.insert(cc_maps, 530)
--- Northrend
-table.insert(cc_maps, 571)
+local CarbonCopyConfig = require("CarbonCopy_Config")
+local Config = CarbonCopyConfig.Config
+local cc_maps = CarbonCopyConfig.cc_maps
+local ticket_Cost = CarbonCopyConfig.ticket_Cost
 
 
 ------------------------------------------

--- a/CarbonCopy.lua
+++ b/CarbonCopy.lua
@@ -72,6 +72,7 @@ function cc_CopyCharacter(event, player, command, chatHandler)
             if commandArray[3] == nil then
                 chatHandler:SendSysMessage("Syntax: .carboncopy tickets lookup $characterName")
                 chatHandler:SendSysMessage("Syntax: .carboncopy tickets add $characterName $amount")
+                chatHandler:SendSysMessage("Syntax: .carboncopy tickets remove $characterName $amount")
                 cc_resetVariables()
                 return false
             end
@@ -122,9 +123,55 @@ function cc_CopyCharacter(event, player, command, chatHandler)
                 return false
             end
 
+            if ticketsAction == "remove" then
+                if commandArray[4] == nil or commandArray[5] == nil then
+                    chatHandler:SendSysMessage("Syntax: .carboncopy tickets remove $characterName $amount")
+                    cc_resetVariables()
+                    return false
+                end
+
+                if tonumber(commandArray[5]) == nil or tonumber(commandArray[5]) > 1000 or tonumber(commandArray[5]) < 0 then
+                    chatHandler:SendSysMessage("Too large or negative amount chosen for .carboncopy tickets remove: "..commandArray[5]..". Max allowed is +1000.")
+                    cc_resetVariables()
+                    return false
+                end
+
+                local normalisedCharacterName = cc_normalizeCharacterName(commandArray[4])
+                local Data_SQL = CharDBQuery("SELECT `account` FROM `characters` WHERE `name` = '"..normalisedCharacterName.."' LIMIT 1;")
+                local accountId
+                local oldTickets
+                if Data_SQL ~= nil then
+                    accountId = Data_SQL:GetUInt32(0)
+                else
+                    chatHandler:SendSysMessage("Player name not found. Syntax: .carboncopy tickets remove $characterName $amount")
+                    cc_resetVariables()
+                    return false
+                end
+
+                Data_SQL = CharDBQuery('SELECT `tickets` FROM `'..Config.customDbName..'`.`carboncopy` WHERE `account_id` = '..accountId..' LIMIT 1;')
+                if Data_SQL ~= nil then
+                    oldTickets = Data_SQL:GetUInt32(0)
+                else
+                    oldTickets = 0
+                end
+
+                if oldTickets <= 0 or oldTickets < tonumber(commandArray[5]) then
+                    chatHandler:SendSysMessage("The account does not have enough tickets to remove "..commandArray[5]..". Current value: "..oldTickets)
+                    cc_resetVariables()
+                    return false
+                end
+
+                CharDBQuery('DELETE FROM `'..Config.customDbName..'`.`carboncopy` WHERE `account_id` = '..accountId..';')
+                CharDBQuery('INSERT INTO `'..Config.customDbName..'`.`carboncopy` VALUES ('..accountId..', '..oldTickets - commandArray[5]..', 0);')
+                chatHandler:SendSysMessage("The console has sucessfully used the .carboncopy tickets remove command, removing "..commandArray[5].." tickets from the account "..accountId.." which belongs to player "..normalisedCharacterName..".")
+                cc_resetVariables()
+                return false
+            end
+
             if ticketsAction ~= "lookup" then
                 chatHandler:SendSysMessage("Syntax: .carboncopy tickets lookup $characterName")
                 chatHandler:SendSysMessage("Syntax: .carboncopy tickets add $characterName $amount")
+                chatHandler:SendSysMessage("Syntax: .carboncopy tickets remove $characterName $amount")
                 cc_resetVariables()
                 return false
             end
@@ -175,6 +222,7 @@ function cc_CopyCharacter(event, player, command, chatHandler)
             chatHandler:SendSysMessage("Syntax: .carboncopy $newCharacterName")
             chatHandler:SendSysMessage("Syntax: .carboncopy tickets lookup $characterName")
             chatHandler:SendSysMessage("Syntax: .carboncopy tickets add $characterName $amount")
+            chatHandler:SendSysMessage("Syntax: .carboncopy tickets remove $characterName $amount")
             cc_resetVariables()
             return false
         end
@@ -200,6 +248,7 @@ function cc_CopyCharacter(event, player, command, chatHandler)
             if commandArray[3] == nil then
                 chatHandler:SendSysMessage("Syntax: .carboncopy tickets lookup $characterName")
                 chatHandler:SendSysMessage("Syntax: .carboncopy tickets add $characterName $amount")
+                chatHandler:SendSysMessage("Syntax: .carboncopy tickets remove $characterName $amount")
                 cc_resetVariables()
                 return false
             end
@@ -256,9 +305,61 @@ function cc_CopyCharacter(event, player, command, chatHandler)
                 return false
             end
 
+            if ticketsAction == "remove" then
+                if player:GetGMRank() < Config.minGMRankForTickets then
+                    chatHandler:SendSysMessage("You lack permisisions to execute this command.")
+                    cc_resetVariables()
+                    return false
+                end
+
+                if commandArray[4] == nil or commandArray[5] == nil then
+                    chatHandler:SendSysMessage("Syntax: .carboncopy tickets remove $characterName $amount")
+                    cc_resetVariables()
+                    return false
+                end
+
+                if tonumber(commandArray[5]) == nil or tonumber(commandArray[5]) > 1000 or tonumber(commandArray[5]) < 0 then
+                    chatHandler:SendSysMessage("Too large or negative amount chosen for .carboncopy tickets remove: "..commandArray[5]..". Max allowed is +1000.")
+                    cc_resetVariables()
+                    return false
+                end
+
+                local normalisedCharacterName = cc_normalizeCharacterName(commandArray[4])
+                local Data_SQL = CharDBQuery("SELECT `account` FROM `characters` WHERE `name` = '"..normalisedCharacterName.."' LIMIT 1;")
+                local removeAccountId
+                local oldTickets
+                if Data_SQL ~= nil then
+                    removeAccountId = Data_SQL:GetUInt32(0)
+                else
+                    chatHandler:SendSysMessage("Player name not found. Syntax: .carboncopy tickets remove $characterName $amount")
+                    cc_resetVariables()
+                    return false
+                end
+
+                Data_SQL = CharDBQuery('SELECT `tickets` FROM `'..Config.customDbName..'`.`carboncopy` WHERE `account_id` = '..removeAccountId..' LIMIT 1;')
+                if Data_SQL ~= nil then
+                    oldTickets = Data_SQL:GetUInt32(0)
+                else
+                    oldTickets = 0
+                end
+
+                if oldTickets <= 0 or oldTickets < tonumber(commandArray[5]) then
+                    chatHandler:SendSysMessage("The account does not have enough tickets to remove "..commandArray[5]..". Current value: "..oldTickets)
+                    cc_resetVariables()
+                    return false
+                end
+
+                CharDBQuery('DELETE FROM `'..Config.customDbName..'`.`carboncopy` WHERE `account_id` = '..removeAccountId..';')
+                CharDBQuery('INSERT INTO `'..Config.customDbName..'`.`carboncopy` VALUES ('..removeAccountId..', '..oldTickets - commandArray[5]..', 0);')
+                chatHandler:SendSysMessage("GM "..player:GetName().. " has sucessfully used the .carboncopy tickets remove command, removing "..commandArray[5].." tickets from the account "..removeAccountId.." which belongs to player "..normalisedCharacterName..".")
+                cc_resetVariables()
+                return false
+            end
+
             if ticketsAction ~= "lookup" then
                 chatHandler:SendSysMessage("Syntax: .carboncopy tickets lookup $characterName")
                 chatHandler:SendSysMessage("Syntax: .carboncopy tickets add $characterName $amount")
+                chatHandler:SendSysMessage("Syntax: .carboncopy tickets remove $characterName $amount")
                 cc_resetVariables()
                 return false
             end

--- a/CarbonCopy.lua
+++ b/CarbonCopy.lua
@@ -277,10 +277,27 @@ function cc_CopyCharacter(event, player, command, chatHandler)
         cc_playerString = player:GetClassAsString(0)
         PrintInfo("1) The player with GUID "..cc_playerGUID.." has succesfully initiated the .carboncopy command. Target character: "..cc_newCharacter);
         chatHandler:SendSysMessage("Copy started. You have been charged "..requiredTickets.." ticket(s) for this action. There are "..availableTickets - requiredTickets.." ticket()s left.")
-        chatHandler:SendSysMessage("STAY logged in for one minute!")
-        chatHandler:SendSysMessage("RIMANENTE connessi per un minuto!")
-        chatHandler:SendSysMessage("MANTENTE conectado por un minuto!")
-        chatHandler:SendSysMessage("BLEIB eingeloggt für eine Minute!")
+        local stayMsgEnglish = "STAY logged in for one minute!"
+        local stayMsgItalian = "RIMANI connesso per un minuto!"
+        local locale = player:GetDbcLocale()
+        local stayMsgByLocale = {
+            [1] = "1분 동안 접속 상태를 유지하세요!",    -- koKR
+            [2] = "RESTEZ connecte pendant une minute!", -- frFR
+            [3] = "BLEIB eingeloggt für eine Minute!", -- deDE
+            [4] = "请保持在线一分钟！",                    -- zhCN
+            [5] = "請保持在線一分鐘！",                    -- zhTW
+            [6] = "MANTENTE conectado por un minuto!", -- esES
+            [7] = "MANTENTE conectado por un minuto!", -- esMX
+            [8] = "ОСТАВАЙТЕСЬ В ИГРЕ ОДНУ МИНУТУ!"    -- ruRU
+        }
+        local localizedStayMsg = stayMsgByLocale[locale]
+
+        -- Display English and Italian (as Italian doesn't have a locale in Wrath)
+        chatHandler:SendSysMessage(stayMsgEnglish)
+        chatHandler:SendSysMessage(stayMsgItalian)
+        if localizedStayMsg ~= nil then
+            chatHandler:SendSysMessage(localizedStayMsg)
+        end
 
         cc_eventId = CreateLuaEvent(cc_resumeSubRoutine, 1000, 10)
 

--- a/CarbonCopy.lua
+++ b/CarbonCopy.lua
@@ -134,7 +134,7 @@ function cc_CopyCharacter(event, player, command, chatHandler)
 
         cc_playerGUID = tostring(player:GetGUID())
         cc_playerGUID = tonumber(cc_playerGUID)
-        local targetName = commandArray[2]:gsub("^%l", string.upper)
+        local targetName = cc_normalizeCharacterName(commandArray[2])
     
         --check for target character to be on same account
         local Data_SQL = CharDBQuery('SELECT `account` FROM `characters` WHERE `name` = "'..targetName..'" LIMIT 1;');
@@ -560,7 +560,8 @@ function cc_CopyCharacter(event, player, command, chatHandler)
                 return false
             end
 
-            Data_SQL = CharDBQuery("SELECT `account` FROM `characters` WHERE `name` = '"..tostring(commandArray[2]).."' LIMIT 1;");
+            local normalisedCharacterName = cc_normalizeCharacterName(commandArray[2])
+            Data_SQL = CharDBQuery("SELECT `account` FROM `characters` WHERE `name` = '"..normalisedCharacterName.."' LIMIT 1;");
             if Data_SQL ~= nil then
                 accountId = Data_SQL:GetUInt32(0)
             else
@@ -589,7 +590,7 @@ function cc_CopyCharacter(event, player, command, chatHandler)
             Data_SQL = CharDBQuery('DELETE FROM `'..Config.customDbName..'`.`carboncopy` WHERE `account_id` = '..accountId..';');
             Data_SQL = CharDBQuery('INSERT INTO `'..Config.customDbName..'`.`carboncopy` VALUES ('..accountId..', '..commandArray[3] + oldTickets..', 0);');
             Data_SQL = nil
-            chatHandler:SendSysMessage("GM "..player:GetName().. " has sucessfully used the .addcctickets command, adding "..commandArray[3].." tickets to the account "..accountId.." which belongs to player "..commandArray[2]..".")
+            chatHandler:SendSysMessage("GM "..player:GetName().. " has sucessfully used the .addcctickets command, adding "..commandArray[3].." tickets to the account "..accountId.." which belongs to player "..normalisedCharacterName..".")
             cc_resetVariables()
             return false
         else
@@ -611,7 +612,8 @@ function cc_CopyCharacter(event, player, command, chatHandler)
                 return false
             end
 
-            Data_SQL = CharDBQuery("SELECT `account` FROM `characters` WHERE `name` = '"..tostring(commandArray[2]).."' LIMIT 1;");
+            local normalisedCharacterName = cc_normalizeCharacterName(commandArray[2])
+            Data_SQL = CharDBQuery("SELECT `account` FROM `characters` WHERE `name` = '"..normalisedCharacterName.."' LIMIT 1;");
             if Data_SQL ~= nil then
                 accountId = Data_SQL:GetUInt32(0)
             else
@@ -640,7 +642,7 @@ function cc_CopyCharacter(event, player, command, chatHandler)
             Data_SQL = CharDBQuery('DELETE FROM `'..Config.customDbName..'`.`carboncopy` WHERE `account_id` = '..accountId..';');
             Data_SQL = CharDBQuery('INSERT INTO `'..Config.customDbName..'`.`carboncopy` VALUES ('..accountId..', '..commandArray[3] + oldTickets..', 0);');
             Data_SQL = nil
-            chatHandler:SendSysMessage("The console has sucessfully used the .addcctickets command, adding "..commandArray[3].." tickets to the account "..accountId.." which belongs to player "..commandArray[2]..".")
+            chatHandler:SendSysMessage("The console has sucessfully used the .addcctickets command, adding "..commandArray[3].." tickets to the account "..accountId.." which belongs to player "..normalisedCharacterName..".")
             cc_resetVariables()
             return false
         end
@@ -747,6 +749,16 @@ function cc_splitString(inputstr, seperator)
         table.insert(t, str)
     end
     return t
+end
+
+function cc_normalizeCharacterName(name)
+    if name == nil then
+        return nil
+    end
+
+    local normalised = string.lower(name)
+    normalised = normalised:gsub("^%l", string.upper)
+    return normalised
 end
 
 function cc_has_value (tab, val)

--- a/CarbonCopy.lua
+++ b/CarbonCopy.lua
@@ -45,6 +45,9 @@ ticket_Cost[69] = 12
 ticket_Cost[79] = 18
 ticket_Cost[80] = 25	--it costs 25 tickets to copy a character at level 80
 
+-- The ItemID "38" (Recruit's Shirt) will be sent on the mail if slot is empty or doesn't exist.
+-- Applies for Shaman Totems "totemItem[X]" and for nill slots in "item_id[i]".
+
 -- The maps below specify legal locations to use the .carboncopy command.
 -- This is used to prevent dungeon specific gear to be copied e.g. the legendaries from the Kael'thas encounter.
 -- Eastern kingdoms
@@ -103,7 +106,7 @@ function cc_CopyCharacter(event, player, command, chatHandler)
             return false
         end
 
-        -- provide syntax help 
+        -- provide syntax help
         if commandArray[2] == "help" then
             chatHandler:SendSysMessage("Syntax: .carboncopy $NewCharacterName")
             cc_resetVariables()
@@ -376,6 +379,7 @@ function cc_CopyCharacter(event, player, command, chatHandler)
             totemItem[2] = 38
             totemItem[3] = 38
             totemItem[4] = 38
+            totemItem[5] = 38
             local totemsDone = 0
             local Data_SQL
             Data_SQL = CharDBQuery('SELECT itemEntry FROM item_instance WHERE owner_guid = '..cc_playerGUID..' AND itemEntry = 5178 LIMIT 1;')
@@ -413,7 +417,16 @@ function cc_CopyCharacter(event, player, command, chatHandler)
             end
             Data_SQL = nil
 
-            SendMail("Copied items", "Hello "..targetName..Config.mailText, cc_newCharacter, 0, 61, 0, 0, 0, totemItem[1], 1, totemItem[2], 1, totemItem[3], 1, totemItem[4], 1)
+            local Data_SQL
+            Data_SQL = CharDBQuery('SELECT itemEntry FROM item_instance WHERE owner_guid = '..cc_playerGUID..' AND itemEntry = 46978 LIMIT 1;')
+            if Data_SQL ~= nil then
+                if Data_SQL:GetUInt16(0) == 46978 then
+                    totemItem[5] = 46978
+                end
+            end
+            Data_SQL = nil
+
+            SendMail("Copied items", "Hello "..targetName..Config.mailText, cc_newCharacter, 0, 61, 0, 0, 0, totemItem[1], 1, totemItem[2], 1, totemItem[3], 1, totemItem[4], 1, totemItem[5], 1)
 
             Data_SQL = nil
             totemsDone = nil

--- a/CarbonCopy.lua
+++ b/CarbonCopy.lua
@@ -157,7 +157,7 @@ function cc_CopyCharacter(event, player, command, chatHandler)
 
         if player == nil then
             chatHandler:SendSysMessage("This command can not be run from the console, but only from the character to copy.")
-            chatHandler:SendSysMessage("Syntax: .addcctickets $characterName $amount")
+            chatHandler:SendSysMessage("Syntax: .addcctickets $characterName $amount") -- Kept for Legacy / Compatibility
             return false
         end
         -- make sure the player is properly ranked
@@ -708,7 +708,6 @@ function cc_CopyCharacter(event, player, command, chatHandler)
         return false
 
     elseif commandArray[1] == "addcctickets" then
-        -- Kept for Legacy / Compotability
         -- make sure the player is properly ranked
         local accountId
         local oldTickets
@@ -719,12 +718,12 @@ function cc_CopyCharacter(event, player, command, chatHandler)
                 return false
             end
             if commandArray[2] == "help" then
-                chatHandler:SendSysMessage("Syntax: .addcctickets $characterName $amount")
+                chatHandler:SendSysMessage("Syntax: .addcctickets $characterName $amount") -- Kept for Legacy / Compatibility
                 cc_resetVariables()
                 return false
             end
             if commandArray[2] == nil or commandArray[3] == nil then
-                chatHandler:SendSysMessage("Syntax: .addcctickets $characterName $amount")
+                chatHandler:SendSysMessage("Syntax: .addcctickets $characterName $amount") -- Kept for Legacy / Compatibility
                 cc_resetVariables()
                 return false
             end
@@ -771,12 +770,12 @@ function cc_CopyCharacter(event, player, command, chatHandler)
         else
             --player is nil, must be the console. no need to check gm rank and print to console only. not chat
             if commandArray[2] == "help" then
-                chatHandler:SendSysMessage("Syntax: .addcctickets $characterName $amount")
+                chatHandler:SendSysMessage("Syntax: .addcctickets $characterName $amount") -- Kept for Legacy / Compatibility
                 cc_resetVariables()
                 return false
             end
             if commandArray[2] == nil or commandArray[3] == nil then
-                chatHandler:SendSysMessage("Syntax: .addcctickets $characterName $amount")
+                chatHandler:SendSysMessage("Syntax: .addcctickets $characterName $amount") -- Kept for Legacy / Compatibility
                 cc_resetVariables()
                 return false
             end

--- a/CarbonCopy_Config.lua
+++ b/CarbonCopy_Config.lua
@@ -1,0 +1,47 @@
+local Config = {}
+local cc_maps = {}
+local ticket_Cost = {}
+
+-- Name of Eluna dB scheme
+Config.customDbName = 'ac_eluna'
+-- Min GM Level to use the .carboncopy command. Set to 0 for all players.
+Config.minGMRankForCopy = 0
+-- Min GM Level to add tickets to an account.
+Config.minGMRankForTickets = 2
+-- The amount of free tickets to grant when .carboncopy is executed for the first time on that account
+Config.freeTickets = 1
+-- This text is added to the mail which the new character receives alongside their copied items
+Config.mailText = ",\n \n here you are your gear. Have fun with the new twink!\n \n- Sincerely,\n the team of ChromieCraft!"
+-- Maximum level to allow copying a character.
+Config.maxLevel = 70
+-- Whether the ticket amount withdrawn for a copy is always 1 (set it to "single") or depends on the level (set this to "level")
+Config.ticketCost = "level"
+-- Here you can adjust the cost in tickets if Config.ticketCost is set to "level"
+ticket_Cost[19] = 1      --it costs 1 ticket to copy a character up to level 19
+ticket_Cost[29] = 2
+ticket_Cost[39] = 3
+ticket_Cost[49] = 5
+ticket_Cost[59] = 8
+ticket_Cost[69] = 12
+ticket_Cost[79] = 18
+ticket_Cost[80] = 25     --it costs 25 tickets to copy a character at level 80
+
+-- The ItemID "38" (Recruit's Shirt) will be sent on the mail if slot is empty or doesn't exist.
+-- Applies for Shaman Totems "totemItem[X]" and for nill slots in "item_id[i]".
+
+-- The maps below specify legal locations to use the .carboncopy command.
+-- This is used to prevent dungeon specific gear to be copied e.g. the legendaries from the Kael'thas encounter.
+-- Eastern kingdoms
+cc_maps[1] = 0
+-- Kalimdor
+cc_maps[2] = 1
+-- Outland
+cc_maps[3] = 530
+-- Northrend
+cc_maps[4] = 571
+
+return {
+    Config = Config,
+    cc_maps = cc_maps,
+    ticket_Cost = ticket_Cost,
+}

--- a/README.md
+++ b/README.md
@@ -1,41 +1,92 @@
-## lua-carbon-copy
-LUA script for Azerothcore with ElunaLUA to allow players to keep copies of their characters at a stage, e.g. for twink pvp.
+# Acore_CarbonCopy
 
-This branch delays the copy process and splits it into 10 pieces to reduce core lag.
+It's a Lua script made for [AzerothCore](https://github.com/azerothcore/azerothcore-wotlk) to allow players to make copies of their characters at specific level of their choosing, an example allowing to have a PVP Twink.
+
+> [!NOTE]
+> This script delays the copy process and splits it into 10 pieces to reduce core / server lag.
+
 
 **Proudly hosted on [ChromieCraft](https://www.chromiecraft.com/)**
 #### Find me on patreon: https://www.patreon.com/Honeys
 
+There a showcase of the video "[CarbonCopy Feature](https://youtu.be/zDdODWPlbLU?si=vCL9TL34lXSCRklB&t=72)".
+
 ## Requirements:
 
-Compile your [Azerothcore](https://github.com/azerothcore/azerothcore-wotlk) with [Eluna Lua](https://www.azerothcore.org/catalogue-details.html?id=131435473), latest version, at least from March 19th, 2021.
+- Requires [mod-ale](https://github.com/azerothcore/mod-ale) (**A**zerothCore **L**ua **E**ngine) to work.
 
-The ElunaLua module itself doesn't require much setup/config. Just specify the subfolder where to put your lua_scripts in its .conf file.
+- If you're using the default `lua_scripts` folder than your `mod_ale.conf` should have `ALE.ScriptPath = "lua_scripts"`, otherwise adjust the path accordingly.
 
-If the directory was not changed, add the .lua script to your `../lua_scripts/` directory.
-Adjust the top part of the .lua file with the config flags.
+- Requires setup of `CarbonCopy_Config.lua` file if you wish to change the values. (`.reload ale` will update the server with the configuration of the file related to the `CarbonCopy` script.)
 
-**On first startup of the core, a scheme specified in the config part of the .lua file will be created.**
+- Adjust `local CarbonCopyConfig = require("CarbonCopy_Config")` of your `CarbonCopy.lua` to match the path of your configuration, by default these two files `CarbonCopy.lua` and `CarbonCopy_Config.lua` should be in the same place.
 
-## Admin Usage:
+## Player Usage:
+
+- `.carboncopy help`
+- `.carboncopy` - Show your current tickets (to be used in-game.)
+- `.carboncopy $newCharacterName` - To Start Carbon Copy to given character name.
+
+## Adminstrator Usage:
+
+- `.carboncopy tickets help`
+- `.carboncopy tickets lookup CharacterName` - See how many tickets a character has.
+- `.carboncopy tickets add CharacterName Amount` - Add tickets to a character's account.
+- `.carboncopy tickets remove CharacterName Amount` - Remove tickets from a character's account.
+- `.addcctickets help` - [Kept for: Legacy/Compatibility]
+- `.addcctickets CharacterName Amount`- [Kept for: Legacy/Compatibility
+] Add tickets to a character's account.
+- `CCACCOUNTTICKETS accountName amount` - Used by [SOAP](https://www.azerothcore.org/wiki/remote-access#soap) for [acore-cms](https://github.com/azerothcore/acore-cms).
+
+## Configuration
+
+```
+customDbName = "ac_eluna" -- Name of the database schema used for CarbonCopy data.
+minGMRankForCopy = 0 -- Minimum GM rank required to use .carboncopy.
+minGMRankForTickets = 2 -- Minimum GM rank required to add or remove tickets.
+freeTickets = 1 -- Tickets granted when an account uses CarbonCopy for the first time.
+mailText = ",\n \n here you are your gear. Have fun with the new twink!\n \n- Sincerely,\n the team of ChromieCraft!" -- Text included in the item mail.
+maxLevel = 70 -- Maximum source character level allowed for copying.
+ticketCost = "level" -- "single" = always 1 ticket, "level" = use ticket_Cost table.
+
+ticket_Cost[19] = 1 -- Cost to copy characters up to level 19.
+ticket_Cost[29] = 2 -- Cost to copy characters up to level 29.
+ticket_Cost[39] = 3 -- Cost to copy characters up to level 39.
+ticket_Cost[49] = 5 -- Cost to copy characters up to level 49.
+ticket_Cost[59] = 8 -- Cost to copy characters up to level 59.
+ticket_Cost[69] = 12 -- Cost to copy characters up to level 69.
+ticket_Cost[79] = 18 -- Cost to copy characters up to level 79.
+ticket_Cost[80] = 25 -- Cost to copy level 80 characters.
+-- This can be scable to any level up or down, if scale up make sure maxLevel also gets updated.
+
+cc_maps[1] = 0 -- Eastern Kingdoms
+cc_maps[2] = 1 -- Kalimdor
+cc_maps[3] = 530 -- Outland
+cc_maps[4] = 571 -- Northrend
+-- This allows custom maps if any are used.
+```
 
 Set the conf flags in the top section of the .lua file.
 
 You need to grant account related tickets in the `carboncopy` table:
-- `account_id` refers to the unique guid of the account.
-- `tickets is the # of times a player can copy a character`
-- `allow_copy_from_id` is reserved for future use. 
+- `account_id` is the unique account ID.
+- `tickets` is the number of times an account can copy a character.
+- `allow_copy_from_id` is reserved for future use.
 
-Or use the command for e.g. SOAP interface granting tickets when sent to worldserver console: Syntax: CCACCOUNTTICKETS $accountName $amount
-ingame command to grant tickets, by default restricted to GM-level 2+.
-Syntax: `.addcctickets $characterName $amount`. `.addcctickets help` shows a syntax message.
+You can also grant tickets from console or SOAP:
+- `CCACCOUNTTICKETS accountName amount`
 
-**Most importantly: `Config.ticketCost`**  If this flag is set to "single", every copy will cost *one* ticket.
-If ticketCost is set to "level", the cost in tickets is determined by the `ticket_Cost` config flags.
+You can grant or remove tickets in game (default restriction: GM rank 2+):
+- `.carboncopy tickets add characterName amount`
+- `.carboncopy tickets remove characterName amount`
+- `.addcctickets characterName amount` (kept for legacy compatibility)
 
-## Player Usage:
-- `.carboncopy help` shows a syntax message
-- `.carboncopy` shows the amount of available tickets
+**Most important setting: `ticketCost`**
+- If set to `single`, every copy costs 1 ticket.
+- If set to `level`, ticket cost is determined by the `ticket_Cost[...]` brackets.
+
+## Copy Workflow
+
 
 - Create a new character with same class/race as the one to copy in the same account. Do NOT log it in.
 - Log in with the source character
@@ -44,18 +95,20 @@ If ticketCost is set to "level", the cost in tickets is determined by the `ticke
 - Log on the new character, find a mailbox. Possibly the items in the mail show no enchants/gems. Once you take the items out of the mailbox, all modifications will be visible. On latest AC modifications are visible in the mailbox already.
 
 ## What it does:
-- Delete the new characters starter gear, except the Homestone.
-- Send copies of all items worn to the new character by mail. Including gems and enchants. 
-- Grant the new character the sources level, xp, discovered flightmasters, /played, stats, explored zones, homebind
-- Grant hunters a copy of their **oldest** pet and previously bought stable slots. It's talent points are refunded. Shamans get their low level totems copied if they still have them
-- Complete all quests on the new character, which the source has completed already
-- Grant the new character all gained reputation, talents, glyphs, spells and skills
-- **Place all actions on the new characters bars. If you copy your macro data from one characters /wtf/ directory to the other, you do not need to setup macros either.**
+- Deletes the new character's starter gear, except the Hearthstone.
+- Sends copies of all equipped items to the new character by mail, including gems and enchants.
+- Copies level, XP, discovered flight masters, played time, stats, explored zones, and homebind.
+- For Hunters, copies the **oldest** pet and bought stable slots (pet talent points are refunded).
+- For Shamans, copies low level totems if the source character still has them.
+- Copies completed quests, reputation, talents, glyphs, spells, and character skills (including professions).
+- Places actions on the new character's bars.
+- If you copy macro data from one character's `/wtf/` folder to the other, macro setup is usually not needed.
 
 ## What it **NOT** does:
-- No items from bags/bank are copied. No bags are copied. All starter gear is deleted except the homestone.
-- No gold is copied. The new character will be at zero copper.
-- No achievements are copied. Achievements were made with the source characters and are reserved to them.
+- Does not copy bag or bank items.
+- Does not copy bag containers.
+- Does not copy gold; the new character starts at 0 copper.
+- Does not copy achievements.
 
 Example query to add one free ticket to all existing accounts:
 


### PR DESCRIPTION
- Move the configuration into a config fille allowing servers to have their own configuration withotu b eing overwritten by the script.
- Added
```
- `.carboncopy tickets lookup CharacterName` - See how many tickets a character has.
- `.carboncopy tickets add CharacterName Amount` - Add tickets to a character's account.
- `.carboncopy tickets remove CharacterName Amount` - Remove tickets from a character's account.
```
- Updated the readme.

Tested

TODO: Hopefully implement in the config file a Exlcusion for spells or skills (professions) when copying.